### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 A Model Context Protocol (MCP) server that connects AI assistants to GitHub repositories containing Obsidian vaults. This server enables seamless integration with your knowledge base stored on GitHub, allowing AI assistants to read, search, and analyze your Obsidian notes and documentation.
 
+<a href="https://glama.ai/mcp/servers/@Hint-Services/obsidian-github-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Hint-Services/obsidian-github-mcp/badge" alt="Obsidian GitHub MCP server" />
+</a>
+
 ## Why This Tool?
 
 Many Obsidian users store their vaults in GitHub for backup, versioning, and collaboration. This MCP server bridges the gap between your GitHub-hosted Obsidian vault and AI assistants, enabling:


### PR DESCRIPTION
This PR adds a badge for the [Obsidian GitHub MCP](https://glama.ai/mcp/servers/@Hint-Services/obsidian-github-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Hint-Services/obsidian-github-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Hint-Services/obsidian-github-mcp/badge" alt="Obsidian GitHub MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.